### PR TITLE
Add 'list' subcommand for palette, imageset, sprite, tilemap and bitmap elements

### DIFF
--- a/src/bin/aloevera.yml
+++ b/src/bin/aloevera.yml
@@ -84,6 +84,8 @@ subcommands:
               - input_file:
                   help: Input PNG file name
                   index: 2
+        - list:
+            about: List palettes in a project file
   - imageset:
       about: Import and manipulate image sets
       subcommands:
@@ -114,6 +116,8 @@ subcommands:
               - pixel_depth:
                   help: Target Pixel Depth (8, 4, 2 or 1)
                   index: 3
+        - list:
+            about: List image sets in a project file
   - tilemap:
       about: Import and manipulate tilemaps
       subcommands:
@@ -183,6 +187,8 @@ subcommands:
                   short: c
                   takes_value: true
                   default_value: "0"
+        - list:
+            about: List tilemaps in a project file
   - sprite:
       about: Interpret an existing Imageset as a Sprite
       subcommands:
@@ -195,6 +201,8 @@ subcommands:
               - imageset_id:
                   help: ID of the existing, formatted Imageset to use as a Sprite
                   index: 2
+        - list:
+            about: List sprites in a project file
   - bitmap:
       about: Interpret an existing Imageset as a Bitmap
       subcommands:
@@ -207,3 +215,5 @@ subcommands:
               - imageset_id:
                   help: ID of the existing, formatted Imageset to use as a Bitmap
                   index: 2
+        - list:
+            about: List bitmaps in a project file

--- a/src/cmd/bitmap/command.rs
+++ b/src/cmd/bitmap/command.rs
@@ -52,3 +52,17 @@ pub fn bitmap_init(g_args: &GlobalArgs, args: &BitmapInitArgs) -> Result<(), Err
 
 	Ok(())
 }
+
+pub fn bitmap_list(g_args: &GlobalArgs) -> Result<(), Error> {
+	let proj = common::load_project(g_args.project_file.clone())?;
+	println!("Bitmaps:");
+	for (id, bitmap) in proj.bitmaps {
+		println!(
+			"  {}: width {} depth {}",
+			id,
+			bitmap.width.val_as_u32(),
+			bitmap.depth
+		);
+	}
+	Ok(())
+}

--- a/src/cmd/bitmap/parse.rs
+++ b/src/cmd/bitmap/parse.rs
@@ -39,6 +39,7 @@ pub fn execute_bitmap_command(g_args: &GlobalArgs, args: &ArgMatches) -> Result<
 			let a = arg_parse!(parse_bitmap_init_args(g_args, args));
 			command::bitmap_init(g_args, &a)
 		}
+		("list", Some(_)) => command::bitmap_list(g_args),
 		_ => {
 			let msg = format!("Unknown sub command, use 'aloevera bitmap --help' for details");
 			return Err(ErrorKind::ArgumentError(msg).into());

--- a/src/cmd/imageset/command.rs
+++ b/src/cmd/imageset/command.rs
@@ -79,3 +79,29 @@ pub fn imageset_format(g_args: &GlobalArgs, args: &ImageSetFormatArgs) -> Result
 
 	Ok(())
 }
+
+/// Imageset list
+pub fn imageset_list(g_args: &GlobalArgs) -> Result<(), Error> {
+	let proj = common::load_project(g_args.project_file.clone())?;
+	println!("Image sets:");
+	for (id, imageset) in proj.imagesets {
+		match imageset.depth {
+			None => println!(
+				"  {}: {} {}x{} frames",
+				id,
+				imageset.frame_data.len(),
+				imageset.frame_width,
+				imageset.frame_height
+			),
+			pixel_depth => print!(
+				"  {}: {} {}x{} frames depth {}",
+				id,
+				imageset.frame_data.len(),
+				imageset.frame_width,
+				imageset.frame_height,
+				pixel_depth.unwrap()
+			),
+		}
+	}
+	Ok(())
+}

--- a/src/cmd/imageset/parse.rs
+++ b/src/cmd/imageset/parse.rs
@@ -81,6 +81,7 @@ pub fn execute_imageset_command(g_args: &GlobalArgs, args: &ArgMatches) -> Resul
 			let a = arg_parse!(parse_imageset_format_args(g_args, args));
 			command::imageset_format(g_args, &a)
 		}
+		("list", Some(_)) => command::imageset_list(g_args),
 		_ => {
 			let msg = format!("Unknown sub command, use 'aloevera imageset --help' for details");
 			return Err(ErrorKind::ArgumentError(msg).into());

--- a/src/cmd/palette/command.rs
+++ b/src/cmd/palette/command.rs
@@ -48,3 +48,22 @@ pub fn palette_import(g_args: &GlobalArgs, args: &PaletteImportArgs) -> Result<(
 
 	Ok(())
 }
+
+/// Palette list command
+pub fn palette_list(g_args: &GlobalArgs) -> Result<(), Error> {
+	// load up the project json
+	let project_file = match &g_args.project_file {
+		Some(f) => f,
+		None => {
+			return Err(ErrorKind::ArgumentError("Missing project file name".to_string()).into())
+		}
+	};
+	let proj_json: String = common::read_file_string(&project_file)?;
+	let proj = AloeVeraProject::new_from_json(&proj_json)?;
+	println!("Palettes:");
+	for (id, palette) in proj.palettes {
+		println!("  {}: {} colors", id, palette.len());
+	}
+
+	Ok(())
+}

--- a/src/cmd/palette/parse.rs
+++ b/src/cmd/palette/parse.rs
@@ -39,6 +39,7 @@ pub fn execute_palette_command(g_args: &GlobalArgs, args: &ArgMatches) -> Result
 			let a = arg_parse!(parse_palette_import_args(g_args, args));
 			command::palette_import(g_args, &a)
 		}
+		("list", Some(_)) => command::palette_list(g_args),
 		_ => {
 			let msg = format!("Unknown sub command, use 'aloevera palette --help' for details");
 			return Err(ErrorKind::ArgumentError(msg).into());

--- a/src/cmd/sprite/command.rs
+++ b/src/cmd/sprite/command.rs
@@ -52,3 +52,19 @@ pub fn sprite_init(g_args: &GlobalArgs, args: &SpriteInitArgs) -> Result<(), Err
 
 	Ok(())
 }
+
+/// Sprite list command
+pub fn sprite_list(g_args: &GlobalArgs) -> Result<(), Error> {
+	let proj = common::load_project(g_args.project_file.clone())?;
+	println!("Sprites:");
+	for (id, sprite) in proj.sprites {
+		print!(
+			"  {}: {}x{} depth {}",
+			id,
+			sprite.frame_width.val_as_u32(),
+			sprite.frame_height.val_as_u32(),
+			sprite.depth
+		);
+	}
+	Ok(())
+}

--- a/src/cmd/sprite/parse.rs
+++ b/src/cmd/sprite/parse.rs
@@ -39,6 +39,7 @@ pub fn execute_sprite_command(g_args: &GlobalArgs, args: &ArgMatches) -> Result<
 			let a = arg_parse!(parse_sprite_init_args(g_args, args));
 			command::sprite_init(g_args, &a)
 		}
+		("list", Some(_)) => command::sprite_list(g_args),
 		_ => {
 			let msg = format!("Unknown sub command, use 'aloevera sprite --help' for details");
 			return Err(ErrorKind::ArgumentError(msg).into());

--- a/src/cmd/tilemap/command.rs
+++ b/src/cmd/tilemap/command.rs
@@ -101,3 +101,21 @@ pub fn tilemap_load(g_args: &GlobalArgs, args: &LoadTileMapArgs) -> Result<(), E
 
 	Ok(())
 }
+
+/// Tilemap list command
+pub fn tilemap_list(g_args: &GlobalArgs) -> Result<(), Error> {
+	let proj = common::load_project(g_args.project_file.clone())?;
+	println!("Tilemaps:");
+	for (id, tilemap) in proj.tilemaps {
+		println!(
+			"  {}: map {}x{} tiles {}x{} mode {}",
+			id,
+			tilemap.map_width(),
+			tilemap.map_height(),
+			tilemap.tile_width(),
+			tilemap.tile_height(),
+			tilemap.mode
+		);
+	}
+	Ok(())
+}

--- a/src/cmd/tilemap/parse.rs
+++ b/src/cmd/tilemap/parse.rs
@@ -87,6 +87,7 @@ pub fn execute_tilemap_command(g_args: &GlobalArgs, args: &ArgMatches) -> Result
 			let a = arg_parse!(parse_load_tilemap_args(g_args, args));
 			command::tilemap_load(g_args, &a)
 		}
+		("list", Some(_)) => command::tilemap_list(g_args),
 		_ => {
 			let msg = format!("Unknown sub command, use 'aloevera tilemap --help' for details");
 			return Err(ErrorKind::ArgumentError(msg).into());

--- a/vera/src/bitmap.rs
+++ b/vera/src/bitmap.rs
@@ -38,7 +38,7 @@ impl fmt::Display for VeraBitmapDim {
 }
 
 impl VeraBitmapDim {
-	fn val_as_u32(&self) -> u32 {
+	pub fn val_as_u32(&self) -> u32 {
 		match self {
 			VeraBitmapDim::Dim320 => 320,
 			VeraBitmapDim::Dim640 => 640,

--- a/vera/src/sprite.rs
+++ b/vera/src/sprite.rs
@@ -44,7 +44,7 @@ impl fmt::Display for VeraSpriteDim {
 }
 
 impl VeraSpriteDim {
-	fn _val_as_u32(&self) -> u32 {
+	pub fn val_as_u32(&self) -> u32 {
 		match self {
 			VeraSpriteDim::Dim8 => 8,
 			VeraSpriteDim::Dim16 => 16,

--- a/vera/src/tilemap.rs
+++ b/vera/src/tilemap.rs
@@ -322,6 +322,26 @@ impl VeraTileMap {
 		self.tiles.len() * 2
 	}
 
+	/// map width as u32
+	pub fn map_width(&self) -> u32 {
+		self.map_width.val_as_u32()
+	}
+
+	/// map height as u32
+	pub fn map_height(&self) -> u32 {
+		self.map_height.val_as_u32()
+	}
+
+	/// tile width as u32
+	pub fn tile_width(&self) -> u32 {
+		self.tile_height.val_as_u32()
+	}
+
+	/// tile height as u32
+	pub fn tile_height(&self) -> u32 {
+		self.tile_height.val_as_u32()
+	}
+
 	/// Return data formatted appropriately for the current map mode
 	fn entry_from_image(
 		&self,


### PR DESCRIPTION
Just getting my feet wet with Rust :).  This PR adds a `list` subcommand for the above elements so the user running `aloevera` interactively on a project file can see a summary of what elements exist.

Sample output (logging elided):
```bash
> aloevera -p /tmp/test.av palette list
Palettes:
  kq5_pal: 256 colors

> aloevera -p /tmp/test.av bitmap list
Bitmaps:
  kq5_bmp: width 320 depth 8

> aloevera -p /tmp/test.av imageset list
Image sets:
  kq5_screen: 1 320x100 frames depth 8

> aloevera -p /tmp/chopper.av sprite list
Sprites:
  chopper_sprite: 64x32 depth 4

> aloevera -p /tmp/chopper.av tilemap list
Tilemaps:
  chopper_tilemap: map 128x64 tiles 8x8 mode Tile4BPP
```