### PR TITLE
Add support for importing palette based on Gimp .gpl files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "aloevera_util 0.2.2",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gimp_palette 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "permutate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -275,6 +276,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "gimli"
 version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gimp_palette"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -853,6 +859,7 @@ dependencies = [
 "checksum fscommon 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84b4c932d50705767a650d5933446acd532e6c2bdb00179c2f145018612368f"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum gimli 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+"checksum gimp_palette 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ab8d53d8a2ad644f6a0f7271b6df57c441d6fa564bc0ab23981b9e0976cdda"
 "checksum hermit-abi 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,6 @@ dependencies = [
  "aloevera_util 0.2.2",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "gimp_palette 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "permutate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -276,11 +275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "gimli"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "gimp_palette"
-version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -859,7 +853,6 @@ dependencies = [
 "checksum fscommon 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84b4c932d50705767a650d5933446acd532e6c2bdb00179c2f145018612368f"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum gimli 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
-"checksum gimp_palette 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ab8d53d8a2ad644f6a0f7271b6df57c441d6fa564bc0ab23981b9e0976cdda"
 "checksum hermit-abi 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"

--- a/src/cmd/palette/command.rs
+++ b/src/cmd/palette/command.rs
@@ -34,7 +34,7 @@ pub fn palette_import(g_args: &GlobalArgs, args: &PaletteImportArgs) -> Result<(
 				include_defaults: false,
 				sort: false,
 			};
-			VeraPalette::derive_from_gpl(&args.id, &args.input_file, &pal_config).expect("Error")
+			VeraPalette::derive_from_gpl(&args.id, &args.input_file, &pal_config)?
 		}
 		false => {
 			let png_bytes = common::read_file_bin(&args.input_file)?;
@@ -43,7 +43,7 @@ pub fn palette_import(g_args: &GlobalArgs, args: &PaletteImportArgs) -> Result<(
 				include_defaults: false,
 				sort: false,
 			};
-			VeraPalette::derive_from_png(&args.id, png_bytes, &pal_config).expect("error")
+			VeraPalette::derive_from_png(&args.id, png_bytes, &pal_config)?
 		}
 	};
 	// load up the project json

--- a/src/cmd/palette/command.rs
+++ b/src/cmd/palette/command.rs
@@ -24,26 +24,46 @@ pub struct PaletteImportArgs {
 	pub input_file: String,
 }
 
+#[derive(Debug)]
+/// Supported palette file types
+enum PaletteFileType {
+	PNG,
+	GPL,
+}
+
+fn vec_compare(va: &[u8], vb: &[u8]) -> bool {
+	(va.len() >= vb.len()) && va.iter().zip(vb).all(|(a, b)| a == b)
+}
+
+fn determine_file_type(data: &Vec<u8>) -> Result<PaletteFileType, Error> {
+	// 8-byte PNG file header as described here: https://en.wikipedia.org/wiki/Portable_Network_Graphics#File_header
+	const PNG_BYTES: [u8; 8] = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+	// First line of Gimp gpl file excluding line ending: "GIMP Palette"
+	const GPL_BYTES: [u8; 12] = [71, 73, 77, 80, 32, 80, 97, 108, 101, 116, 116, 101];
+
+	if vec_compare(data, &PNG_BYTES) {
+		return Ok(PaletteFileType::PNG);
+	}
+	if vec_compare(data, &GPL_BYTES) {
+		return Ok(PaletteFileType::GPL);
+	}
+	return Err(ErrorKind::ArgumentError("Invalid palette file".to_string()).into());
+}
+
 /// Palette import command
 pub fn palette_import(g_args: &GlobalArgs, args: &PaletteImportArgs) -> Result<(), Error> {
-	let is_gpl = args.input_file.ends_with("gpl") || args.input_file.ends_with("GPL");
-	let palette = match is_gpl {
-		true => {
-			let pal_config = VeraPaletteLoadConfig {
-				direct_load: true,
-				include_defaults: false,
-				sort: false,
-			};
-			VeraPalette::derive_from_gpl(&args.id, &args.input_file, &pal_config)?
-		}
-		false => {
-			let png_bytes = common::read_file_bin(&args.input_file)?;
-			let pal_config = VeraPaletteLoadConfig {
-				direct_load: true,
-				include_defaults: false,
-				sort: false,
-			};
-			VeraPalette::derive_from_png(&args.id, png_bytes, &pal_config)?
+	let pal_bytes = common::read_file_bin(&args.input_file)?;
+	let pal_config = VeraPaletteLoadConfig {
+		direct_load: true,
+		include_defaults: false,
+		sort: false,
+	};
+	let file_type = determine_file_type(&pal_bytes);
+	let palette = match file_type {
+		Ok(PaletteFileType::GPL) => VeraPalette::derive_from_gpl(&args.id, pal_bytes, &pal_config)?,
+		Ok(PaletteFileType::PNG) => VeraPalette::derive_from_png(&args.id, pal_bytes, &pal_config)?,
+		Err(s) => {
+			return Err(s);
 		}
 	};
 	// load up the project json

--- a/src/cmd/palette/command.rs
+++ b/src/cmd/palette/command.rs
@@ -26,13 +26,26 @@ pub struct PaletteImportArgs {
 
 /// Palette import command
 pub fn palette_import(g_args: &GlobalArgs, args: &PaletteImportArgs) -> Result<(), Error> {
-	let png_bytes = common::read_file_bin(&args.input_file)?;
-	let pal_config = VeraPaletteLoadConfig {
-		direct_load: true,
-		include_defaults: false,
-		sort: false,
+	let is_gpl = args.input_file.ends_with("gpl") || args.input_file.ends_with("GPL");
+	let palette = match is_gpl {
+		true => {
+			let pal_config = VeraPaletteLoadConfig {
+				direct_load: true,
+				include_defaults: false,
+				sort: false,
+			};
+			VeraPalette::derive_from_gpl(&args.id, &args.input_file, &pal_config).expect("Error")
+		}
+		false => {
+			let png_bytes = common::read_file_bin(&args.input_file)?;
+			let pal_config = VeraPaletteLoadConfig {
+				direct_load: true,
+				include_defaults: false,
+				sort: false,
+			};
+			VeraPalette::derive_from_png(&args.id, png_bytes, &pal_config).expect("error")
+		}
 	};
-	let palette = VeraPalette::derive_from_png(&args.id, png_bytes, &pal_config)?;
 	// load up the project json
 	let project_file = match &g_args.project_file {
 		Some(f) => f,

--- a/util/src/data/palette-gimp.gpl
+++ b/util/src/data/palette-gimp.gpl
@@ -1,0 +1,21 @@
+GIMP Palette
+Name: TestPalette
+Columns: 0
+#
+  0   0   0 Untitled
+ 71  71  71 Untitled
+255 255 255 Untitled
+ 34  68  17 Untitled
+136 102  17 Untitled
+ 79  16  16 Untitled
+ 79  16 176 Untitled
+ 34  34  34 Untitled
+255 255 128 Untitled
+144 255  80 Untitled
+153 153 153 Untitled
+  0   0 112 Untitled
+ 69  36  19 Untitled
+246  25  25 Untitled
+ 25 246 246 Untitled
+233  25 246 Untitled
+

--- a/util/src/gpl.rs
+++ b/util/src/gpl.rs
@@ -1,0 +1,132 @@
+// Copyright 2020 Revcore Technologies Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implements basic support for reading Gimp .gpl files.
+
+/// Parses a Gimp gpl file provided as a vector of bytes into a vector of (r,g,b) tuples.
+pub fn parse_gpl_from_bytes(gpl_data: Vec<u8>) -> Result<Vec<(u8, u8, u8)>, &'static str> {
+	let gpl_string = match String::from_utf8(gpl_data) {
+		Ok(s) => s,
+		_ => {
+			return Err("Invalid gpl file content");
+		}
+	};
+
+	fn is_comment(s: &str) -> bool {
+		s.chars().skip_while(|c| c.is_whitespace()).next() == Some('#')
+	}
+
+	fn validate_line_1(s: &str) -> Result<(), &'static str> {
+		if s != "GIMP Palette" {
+			return Err("Invalid gpl file line 1");
+		}
+		return Ok(());
+	}
+
+	fn validate_line_2(s: &str) -> Result<(), &'static str> {
+		if !s.starts_with("Name:") {
+			return Err("Invalid gpl file line 2");
+		}
+		return Ok(());
+	}
+
+	fn validate_line_3(s: &str) -> Result<(), &'static str> {
+		if !s.starts_with("Columns:") {
+			return Err("Invalid gpl file line 3");
+		}
+		return Ok(());
+	}
+
+	fn parse_rgb_value(s: &str) -> Result<u8, &'static str> {
+		match s.parse::<u8>() {
+			Ok(n) => Ok(n),
+			_ => Err("Failed to parse rgb value"),
+		}
+	}
+
+	let mut colors = vec![];
+	let mut line_num = 0;
+
+	for line in gpl_string.lines() {
+		line_num += 1;
+		if is_comment(&line) || line.trim().len() == 0 {
+			continue;
+		}
+		match line_num {
+			1 => {
+				validate_line_1(line)?;
+			}
+			2 => {
+				validate_line_2(line)?;
+			}
+			3 => {
+				validate_line_3(line)?;
+			}
+			_ => {
+				let mut split = line.split_whitespace();
+				match (split.next(), split.next(), split.next()) {
+					(Some(r_str), Some(g_str), Some(b_str)) => {
+						let r = parse_rgb_value(r_str)?;
+						let g = parse_rgb_value(g_str)?;
+						let b = parse_rgb_value(b_str)?;
+						colors.push((r, g, b));
+					}
+					_ => {
+						return Err("Invalid gpl file");
+					}
+				}
+			}
+		}
+	}
+
+	Ok(colors)
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	#[test]
+	fn test_parse_gpl_from_bytes() {
+		let test_gpl = include_bytes!("data/palette-gimp.gpl");
+
+		match parse_gpl_from_bytes(test_gpl.to_vec()) {
+			Ok(gpl) => {
+				// Note: these values aren't yet scaled down to 4-bit values
+				assert_eq!(gpl[0], (0, 0, 0));
+				assert_eq!(gpl[2], (255, 255, 255));
+				assert_eq!(gpl[4], (136, 102, 17));
+				assert_eq!(gpl[10], (153, 153, 153));
+				assert_eq!(gpl.len(), 16);
+				println!("Read colors from palette:{:?}", gpl);
+				println!("parse_gpl_from_bytes() succeeded on valid gpl file");
+			}
+			_ => {
+				println!("parse_gpl_from_bytes() failed");
+				assert_eq!(false, true)
+			}
+		}
+
+		let invalid_gpl = include_bytes!("data/create.sh");
+
+		match parse_gpl_from_bytes(invalid_gpl.to_vec()) {
+			Err(_) => {
+				println!("parse_gpl_from_bytes() failed as expected");
+			}
+			_ => {
+				println!("parse_gpl_from_bytes() unexpectedly succeeded");
+				assert_eq!(!false, true);
+			}
+		}
+	}
+}

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -38,3 +38,6 @@ pub mod logger;
 pub use crate::logger::{init_logger, init_test_logger};
 
 pub mod hex;
+
+// Parsing Gimp .gpl files
+pub mod gpl;

--- a/vera/Cargo.toml
+++ b/vera/Cargo.toml
@@ -18,3 +18,4 @@ serde_derive = "1"
 png = "0.15"
 permutate = "0.3"
 aloevera_util = { path = "../util", version = "0.2.2" }
+gimp_palette = { version = "0.1.1" }

--- a/vera/Cargo.toml
+++ b/vera/Cargo.toml
@@ -18,4 +18,3 @@ serde_derive = "1"
 png = "0.15"
 permutate = "0.3"
 aloevera_util = { path = "../util", version = "0.2.2" }
-gimp_palette = { version = "0.1.1" }

--- a/vera/tests/data/palette/palette-gimp.gpl
+++ b/vera/tests/data/palette/palette-gimp.gpl
@@ -1,0 +1,21 @@
+GIMP Palette
+Name: TestPalette
+Columns: 0
+#
+  0   0   0 Untitled
+ 71  71  71 Untitled
+255 255 255 Untitled
+ 34  68  17 Untitled
+136 102  17 Untitled
+ 79  16  16 Untitled
+ 79  16 176 Untitled
+ 34  34  34 Untitled
+255 255 128 Untitled
+144 255  80 Untitled
+153 153 153 Untitled
+  0   0 112 Untitled
+ 69  36  19 Untitled
+246  25  25 Untitled
+ 25 246 246 Untitled
+233  25 246 Untitled
+

--- a/vera/tests/palette.rs
+++ b/vera/tests/palette.rs
@@ -82,3 +82,42 @@ fn palette_8bpp_indexed() -> Result<(), Error> {
 
 	Ok(())
 }
+
+#[test]
+fn palette_gimp() -> Result<(), Error> {
+	init_test_logger();
+	// Unclear why the path needs to be different for this test compared to
+	// the other tests which use include_bytes().
+	let test_gpl = "tests/data/palette/palette-gimp.gpl";
+	let pal_config = VeraPaletteLoadConfig {
+		direct_load: true,
+		include_defaults: false,
+		sort: false,
+	};
+	let palette = VeraPalette::derive_from_gpl("pal", &test_gpl, &pal_config)?;
+	assert_eq!(
+		palette.value_at_index(0)?,
+		VeraPaletteEntry { r: 0, g: 0, b: 0 }
+	);
+	assert_eq!(
+		palette.value_at_index(2)?,
+		VeraPaletteEntry {
+			r: 15,
+			g: 15,
+			b: 15
+		}
+	);
+	assert_eq!(
+		palette.value_at_index(4)?,
+		VeraPaletteEntry { r: 8, g: 6, b: 1 }
+	);
+	assert_eq!(
+		palette.value_at_index(10)?,
+		VeraPaletteEntry { r: 9, g: 9, b: 9 }
+	);
+	println!("{}", palette);
+
+	assert_eq!(palette.len(), 16);
+
+	Ok(())
+}

--- a/vera/tests/palette.rs
+++ b/vera/tests/palette.rs
@@ -84,17 +84,15 @@ fn palette_8bpp_indexed() -> Result<(), Error> {
 }
 
 #[test]
-fn palette_gimp() -> Result<(), Error> {
+fn palette_gpl() -> Result<(), Error> {
 	init_test_logger();
-	// Unclear why the path needs to be different for this test compared to
-	// the other tests which use include_bytes().
-	let test_gpl = "tests/data/palette/palette-gimp.gpl";
+	let test_gpl = include_bytes!("data/palette/palette-gimp.gpl");
 	let pal_config = VeraPaletteLoadConfig {
 		direct_load: true,
 		include_defaults: false,
 		sort: false,
 	};
-	let palette = VeraPalette::derive_from_gpl("pal", &test_gpl, &pal_config)?;
+	let palette = VeraPalette::derive_from_gpl("pal", test_gpl.to_vec(), &pal_config)?;
 	assert_eq!(
 		palette.value_at_index(0)?,
 		VeraPaletteEntry { r: 0, g: 0, b: 0 }


### PR DESCRIPTION
This PR uses the [gimp_palette](https://lib.rs/crates/gimp_palette) crate to support importing palette based on a .gpl file.
Sample usage:
```bash
aloevera -p /tmp/test.av palette import gpl_palette Palette.gpl 
20200525 09:09:34.774 INFO aloevera - This is Aloevera version 0.2.2, built for x86_64-unknown-linux-gnu by rustc 1.43.1 (8d69840ab 2020-05-04).
20200525 09:09:34.776 INFO aloevera_vera::palette - Palette creation successful
20200525 09:09:34.776 INFO aloevera::cmd::palette::command - Inserting palette into project: /tmp/test.av
20200525 09:09:34.782 INFO aloevera - Command 'palette' completed successfully
20200525 09:09:34.782 INFO aloevera - Finished
```
The `aloevera palette import` command now looks at the suffix of the palette filename in order to handle either .gpl files or .png files.